### PR TITLE
fixed issue in findresultpage.js 

### DIFF
--- a/client/src/components/views/FindResultPage/FindResultPage.js
+++ b/client/src/components/views/FindResultPage/FindResultPage.js
@@ -8,9 +8,17 @@ const { Meta } = Card;
 
 function FindResultPage(props) {
   const [Users, setUsers] = useState([]);
-  var image =
+  let image =
     "https://static.wadiz.kr/main/media/img-fundingopen-pc@2x.3311937d.jpg";
-  let user = useSelector((state) => state.user.findData).user;
+  let user = useSelector((state) => state.user.findData);
+
+  if (user !== undefined) {
+    user = user.user;
+  }
+  else {
+    props.history.push("/");
+    return (<div></div>);
+  }
 
   console.log("=== === === ");
   console.log(user);


### PR DESCRIPTION
where directly access to /findResult…… crashes the react

증상: user 데이터가 없이 페이지에 접근할 경우(ex. 그냥 주소로 바로 들어오기) 리액트가 crash되는 현상
해결: 데이터 없으면 메인으로 바로 나가도록 퇴거명령을 내림

머지해주세용 ㅎㅎ